### PR TITLE
Support for DROP TABLE

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -1,20 +1,21 @@
-mod select;
-mod insert;
-mod update;
-mod delete;
 mod alter_table;
-mod create_table;
 mod create_index;
 mod create_schema;
+mod create_table;
 mod cte;
+mod delete;
+mod drop_table;
+mod insert;
+mod select;
+mod update;
 
-pub use select::*;
 pub use insert::*;
+pub use select::*;
 pub use update::*;
 // pub use delete::*;
 pub use alter_table::*;
-pub use create_table::*;
 pub use create_index::*;
 pub use create_schema::*;
+pub use create_table::*;
 pub use cte::*;
-
+pub use drop_table::*;

--- a/src/query/alter_table.rs
+++ b/src/query/alter_table.rs
@@ -1,7 +1,7 @@
 use crate::{Dialect, Column, ToSql, Type};
 use crate::util::SqlExtension;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AlterColumnAction {
     SetType {
         typ: Type,
@@ -11,7 +11,7 @@ pub enum AlterColumnAction {
 }
 
 /// Alter table action
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AlterAction {
     AddColumn {
         column: Column,
@@ -41,7 +41,7 @@ impl AlterAction {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AlterTable {
     pub schema: Option<String>,
     pub name: String,

--- a/src/query/create_index.rs
+++ b/src/query/create_index.rs
@@ -1,7 +1,7 @@
 use crate::{Dialect, ToSql};
 use crate::util::SqlExtension;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IndexType {
     BTree,
     Hash,
@@ -17,7 +17,7 @@ impl Default for IndexType {
 }
 
 /// Create index action for a table
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateIndex {
     pub name: String,
     pub unique: bool,

--- a/src/query/create_table.rs
+++ b/src/query/create_table.rs
@@ -2,7 +2,7 @@ use crate::{Dialect, Table, Column, ToSql};
 use crate::util::SqlExtension;
 
 /// Create table action
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateTable {
     pub schema: Option<String>,
     pub name: String,

--- a/src/query/cte.rs
+++ b/src/query/cte.rs
@@ -1,6 +1,6 @@
 use crate::{Dialect, Select, ToSql};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CteQuery {
     Select(Select),
     Raw(String),
@@ -16,7 +16,7 @@ impl ToSql for CteQuery {
 }
 
 /// Common table expression
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Cte {
     pub name: String,
     pub query: CteQuery,

--- a/src/query/drop_table.rs
+++ b/src/query/drop_table.rs
@@ -1,0 +1,38 @@
+use crate::util::SqlExtension;
+use crate::{Dialect, Table, ToSql};
+
+/// Create table action
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DropTable {
+    pub schema: Option<String>,
+    pub name: String,
+}
+
+impl DropTable {
+    pub fn from_table(table: &Table) -> DropTable {
+        DropTable {
+            schema: table.schema.clone(),
+            name: table.name.clone(),
+        }
+    }
+}
+
+impl ToSql for DropTable {
+    fn write_sql(&self, buf: &mut String, _dialect: Dialect) {
+        buf.push_str("DROP TABLE ");
+        buf.push_table_name(&self.schema, &self.name);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_drop_table() {
+        let t = Table::new("test_table");
+        let dt = DropTable::from_table(&t);
+        let sql = dt.to_sql(Dialect::Postgres).to_string();
+        assert_eq!(sql, r#"DROP TABLE "test_table""#);
+    }
+}

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -9,7 +9,7 @@ pub use join::*;
 pub use expr::*;
 
 /// A SELECT query.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Select {
     pub ctes: Vec<Cte>,
     pub distinct: bool,
@@ -145,7 +145,7 @@ impl Select {
 }
 
 /// Represents a select column value.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SelectExpression {
     Column { schema: Option<String>, table: Option<String>, column: String },
     Raw(String),
@@ -153,7 +153,7 @@ pub enum SelectExpression {
 
 
 /// Represents a column of a SELECT statement.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelectColumn {
     pub expression: SelectExpression,
     pub alias: Option<String>,
@@ -221,8 +221,7 @@ impl ToSql for SelectColumn {
     }
 }
 
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct From {
     pub schema: Option<String>,
     pub table: String,
@@ -239,7 +238,7 @@ impl ToSql for From {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Where {
     And(Vec<Where>),
     Or(Vec<Where>),
@@ -280,13 +279,13 @@ impl ToSql for Where {
 }
 
 /// The direction of a column in an ORDER BY clause.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Direction {
     Asc,
     Desc,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrderBy {
     pub column: String,
     pub direction: Direction,
@@ -309,8 +308,7 @@ impl Default for Direction {
     }
 }
 
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GroupBy(String);
 
 impl ToSql for GroupBy {

--- a/src/query/select/expr.rs
+++ b/src/query/select/expr.rs
@@ -1,7 +1,7 @@
 use crate::{Dialect, ToSql};
 use crate::util::SqlExtension;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Case {
     cases: Vec<(Expr, Expr)>,
@@ -44,7 +44,7 @@ impl ToSql for Case {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Expr {
     Case(Case),

--- a/src/query/select/join.rs
+++ b/src/query/select/join.rs
@@ -2,13 +2,13 @@ use crate::{Dialect, Select, ToSql};
 use crate::query::Where;
 use crate::util::SqlExtension;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JoinTable {
     Select(Select),
     Table { schema: Option<String>, table: String },
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum JoinType {
     Inner,
     Left,
@@ -22,7 +22,7 @@ impl Default for JoinType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Criteria {
     On(Where),
     Using(Vec<String>),
@@ -44,7 +44,7 @@ impl ToSql for Criteria {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Join {
     pub typ: JoinType,
     pub table: JoinTable,

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -3,7 +3,7 @@ use crate::query::Where;
 use crate::{Dialect, ToSql};
 use crate::util::SqlExtension;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Update {
     pub ctes: Vec<Cte>,
     pub schema: Option<String>,

--- a/src/schema/column.rs
+++ b/src/schema/column.rs
@@ -2,7 +2,7 @@ use crate::{Type, ToSql, Dialect};
 use crate::query::Expr;
 use crate::util::SqlExtension;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Column {
     pub name: String,

--- a/src/schema/type.rs
+++ b/src/schema/type.rs
@@ -4,7 +4,7 @@ use crate::to_sql::{Dialect, ToSql};
 
 use crate::util::SqlExtension;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Type {
     Boolean,


### PR DESCRIPTION
Hi! Are you open to including a DROP TABLE support? Opening this as a draft for discussion! 

The `MigrationOptions` seems like a good place where I can add a ~`allow_destructive: bool` part to make this not destroy things by default. 


(at the moment this also includes some auto-formatting changes which I can eventually back out if destructive operations are something you're open to including)