### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -3,7 +3,7 @@ name = "kurtbuilds_sql"
 version.workspace = true
 edition.workspace = true
 documentation = "https://docs.rs/kurtbuilds_sql"
-homepage = "https://github.com/kurtbuilds/sql"
+repository = "https://github.com/kurtbuilds/sql"
 license = "MIT"
 description = "Structs representing sql queries, enabling query building, migrations, and more"
 


### PR DESCRIPTION
According to the [manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/104