### PR TITLE
Add create table if not exists

### DIFF
--- a/sql/src/schema/table.rs
+++ b/sql/src/schema/table.rs
@@ -36,7 +36,7 @@ impl Table {
 
 impl ToSql for Table {
     fn write_sql(&self, buf: &mut String, dialect: Dialect) {
-        buf.push_str("CREATE TABLE ");
+        buf.push_str("CREATE TABLE IF NOT EXISTS ");
         buf.push_table_name(&self.schema, &self.name);
         buf.push_str(" (\n");
         buf.push_sql_sequence(&self.columns, ",\n", dialect);


### PR DESCRIPTION
This is a fix for: https://github.com/kurtbuilds/ormlite/issues/66

This will work across sqlite, mysql, and postgres.

Without this, trying to create a table while it already exists will error and requires a hack like: https://github.com/kurtbuilds/ormlite/blob/0b8f38f86a38a8abcd3ea9bb9c22c549b5c60dad/cli/src/command/init.rs#L33

Let me know if you have any questions!